### PR TITLE
Fixed typographical error, changed abritrary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is in no way affiliated with Yahoo, or something equally legal sounding
 
 ## TODO
 
-Add error handling and abstract functions for returning maps of abritrary data with well-
+Add error handling and abstract functions for returning maps of arbitrary data with well-
 formatted dates as keys (look into standard date formatting).
 
 Handle 404 (which manifest as blank csv files that fail upon parsing).


### PR DESCRIPTION
bradshjg, I've corrected a typographical error in the documentation of the [yfq](https://github.com/bradshjg/yfq) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
